### PR TITLE
Refactor miembros to use location and civil status tables

### DIFF
--- a/ajax/tbl_miembros.php
+++ b/ajax/tbl_miembros.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 require_once "../modelos/tbl_miembros.php";
 
 $tbl_miembros = new Tbl_miembros();
@@ -11,112 +11,127 @@ $Mi_Apellido =isset($_POST["Mi_Apellido"])? limpiarCadena($_POST["Mi_Apellido"])
 $Mi_FechaNacimiento =isset($_POST["Mi_FechaNacimiento"])? limpiarCadena($_POST["Mi_FechaNacimiento"]):"";
 $Mi_Celular =isset($_POST["Mi_Celular"])? limpiarCadena($_POST["Mi_Celular"]):"";
 $Mi_Email =isset($_POST["Mi_Email"])? limpiarCadena($_POST["Mi_Email"]):"";
-$Mi_Departamento =isset($_POST["Mi_Departamento"])? limpiarCadena($_POST["Mi_Departamento"]):"";
+$departamento_id =isset($_POST["departamento_id"])? limpiarCadena($_POST["departamento_id"]):"";
+$ciudad_id =isset($_POST["ciudad_id"])? limpiarCadena($_POST["ciudad_id"]):"";
 $Mi_Ocupacion =isset($_POST["Mi_Ocupacion"])? limpiarCadena($_POST["Mi_Ocupacion"]):"";
 $Mi_Direccion =isset($_POST["Mi_Direccion"])? limpiarCadena($_POST["Mi_Direccion"]):"";
 $Mi_tiempo = isset($_POST["Mi_tiempo"])? limpiarCadena($_POST["Mi_tiempo"]) : "";
 $CI = isset($_POST["CI"])? limpiarCadena($_POST["CI"]) : "";
-$Civil = isset($_POST["Civil"])? limpiarCadena($_POST["Civil"]) : "";
+$estado_civil_id = isset($_POST["estado_civil_id"])? limpiarCadena($_POST["estado_civil_id"]) : "";
 $CarnetDiscapacidad = isset($_POST["CarnetDiscapacidad"])? limpiarCadena($_POST["CarnetDiscapacidad"]) : "";
 $imagen = isset($_POST["imagen"])? limpiarCadena($_POST["imagen"]) : "";
 
 // desde un archivo js se hara una peticion a este archivo mandando una opcion
 // preguntamos que opcion es la que nos pidieron
 switch ($_GET["op"]){
-	case 'guardaryeditar':
-		if (!file_exists($_FILES['imagen']['tmp_name']) || !is_uploaded_file($_FILES['imagen']['tmp_name']))
-		{
-			$imagen=$_POST["imagenactual"];
-		}
-		else 
-		{
-			$ext = explode(".", $_FILES["imagen"]["name"]);
-			if ($_FILES['imagen']['type'] == "image/jpg" || $_FILES['imagen']['type'] == "image/jpeg" || $_FILES['imagen']['type'] == "image/png")
-			{
-				$imagen = round(microtime(true)) . '.' . end($ext);    // 5516511651.png
-				move_uploaded_file($_FILES["imagen"]["tmp_name"], "../files/usuarios/" . $imagen);
-			}
-		}
-		// es el mismo case por que nos daremos cuenta con el idcategoria si llega vacio o con datos		
-		if (empty($Mi_id)){
-			$rspta = $tbl_miembros->insertar($Mi_Nombres,$Mi_Apellido,$Mi_FechaNacimiento,$Mi_Celular,$Mi_Email,$Mi_Departamento,$Mi_Ocupacion,$Mi_Direccion,$Mi_tiempo,$CI,$Civil,$CarnetDiscapacidad,$imagen); //rsta viene del modelo 1:ok 0:algo va mal
-			echo $rspta ? "Tbl_miembros registrado" : "Tbl_miembros no se pudo registrar";
-		}
-		else {
-			$rspta = $tbl_miembros->editar($Mi_id,$Mi_Nombres,$Mi_Apellido,$Mi_FechaNacimiento,$Mi_Celular,$Mi_Email,$Mi_Departamento,$Mi_Ocupacion,$Mi_Direccion,$Mi_tiempo,$CI,$Civil,$CarnetDiscapacidad,$imagen);
-			echo $rspta ? "Tbl_miembros actualizada" : "Tbl_miembros no se pudo actualizar";
-		}
-	break;
+        case 'guardaryeditar':
+                if (!file_exists($_FILES['imagen']['tmp_name']) || !is_uploaded_file($_FILES['imagen']['tmp_name']))
+                {
+                        $imagen=$_POST["imagenactual"];
+                }
+                else
+                {
+                        $ext = explode(".", $_FILES["imagen"]["name"]);
+                        if ($_FILES['imagen']['type'] == "image/jpg" || $_FILES['imagen']['type'] == "image/jpeg" || $_FILES['imagen']['type'] == "image/png")
+                        {
+                                $imagen = round(microtime(true)) . '.' . end($ext);    // 5516511651.png
+                                move_uploaded_file($_FILES["imagen"]["tmp_name"], "../files/usuarios/" . $imagen);
+                        }
+                }
+                // es el mismo case por que nos daremos cuenta con el idcategoria si llega vacio o con datos
+                if (empty($Mi_id)){
+                        $rspta = $tbl_miembros->insertar($Mi_Nombres,$Mi_Apellido,$Mi_FechaNacimiento,$Mi_Celular,$Mi_Email,$ciudad_id,$Mi_Ocupacion,$Mi_Direccion,$Mi_tiempo,$CI,$estado_civil_id,$CarnetDiscapacidad,$imagen); //rsta viene del modelo 1:ok 0:algo va mal
+                        echo $rspta ? "Tbl_miembros registrado" : "Tbl_miembros no se pudo registrar";
+                }
+                else {
+                        $rspta = $tbl_miembros->editar($Mi_id,$Mi_Nombres,$Mi_Apellido,$Mi_FechaNacimiento,$Mi_Celular,$Mi_Email,$ciudad_id,$Mi_Ocupacion,$Mi_Direccion,$Mi_tiempo,$CI,$estado_civil_id,$CarnetDiscapacidad,$imagen);
+                        echo $rspta ? "Tbl_miembros actualizada" : "Tbl_miembros no se pudo actualizar";
+                }
+        break;
 
-	case 'desactivar':
-		// cambiamos a 0 el estado con el metodo definido
-		$rspta = $tbl_miembros->desactivar($Mi_id);
- 		echo $rspta ? "Usuario pasivo" : "Usuario no se puede desactivar";
-	break;
+        case 'desactivar':
+                // cambiamos a 0 el estado con el metodo definido
+                $rspta = $tbl_miembros->desactivar($Mi_id);
+                echo $rspta ? "Usuario pasivo" : "Usuario no se puede desactivar";
+        break;
 
-	case 'activar':
-		// cambiamos a 1 el estado con el metodo definido
-		$rspta = $tbl_miembros->activar($Mi_id);
- 		echo $rspta ? "Usuario activo" : "Us no se puede activar";
-	break;
+        case 'activar':
+                // cambiamos a 1 el estado con el metodo definido
+                $rspta = $tbl_miembros->activar($Mi_id);
+                echo $rspta ? "Usuario activo" : "Us no se puede activar";
+        break;
 
-	case 'mostrar':
-		$rspta = $tbl_miembros->mostrar($Mi_id);
- 		//Codificar el resultado utilizando json y lo imprimimos para que se retorne un json
- 		echo json_encode($rspta);
-	break;
-		
+        case 'mostrar':
+                $rspta = $tbl_miembros->mostrar($Mi_id);
+                //Codificar el resultado utilizando json y lo imprimimos para que se retorne un json
+                echo json_encode($rspta);
+        break;
 
-	case 'listar':
-		$rspta=$tbl_miembros->listar();
- 		//Vamos a declarar un array
- 		$data = Array();  //    []
-		// recorremos la tabla de respuestas con un while y dentro una variable reg que toma 
-		// el valor de cada una de las rows de rsta
- 		while ($reg = $rspta->fetch_object()){
-			 // guardamos en el array data los valores de reg
- 			// $data[] = array(
-			// 	"0"=>$reg->idcategoria,
-			// 	"1"=>$reg->nombre,
-			// 	"2"=>$reg->descripcion,
-			// 	"3"=>$reg->condicion
-			// 	);			
-			
-			$data[]=array(
-				
- 				"0"=>($reg->condicion)? '<button class="btn btn-warning" onclick="mostrar('.$reg->Mi_id.')"><i class="fa fa-edit" style="font-size:24px"></i></button>'.
- 					' <button class="btn btn-danger" onclick="desactivar('.$reg->Mi_id.')"> <i class="fa fa-times-rectangle" style="font-size:24px"></i></button>' 
-					 :
- 					'<button class="btn btn-warning" onclick="mostrar('.$reg->Mi_id.')"><i class="fa fa-edit" style="font-size:24px"></i></button>'.
- 					' <button class="btn btn-primary" onclick="activar('.$reg->Mi_id.')"> <i class="fa fa-check-square-o" style="font-size:24px"></i></button>',
 
-				// "0"=>'<button class="btn btn-warning" onclick="mostrar(' . $reg->Mi_id . ')">editar</button>'
-				// .' <button class="btn btn-danger" onclick="desactivar('.$reg->Mi_id.')">descativar</button>'
-				//,
-				
-				"1"=>$reg->Mi_Nombres,
- 				"2"=>$reg->Mi_Apellido,
-				"3"=>$reg->Mi_FechaNacimiento,
-				"4"=>$reg->Mi_Celular,
-				"5"=>$reg->Mi_Email,
-				"6"=>$reg->Mi_Departamento,
-				"7"=>$reg->Mi_Ocupacion,
-				"8"=>$reg->Mi_Direccion,
-				"9"=>$reg->Mi_tiempo,
-				"10"=>$reg->CI,
-				"11"=>$reg->Civil,
-				"12"=>$reg->CarnetDiscapacidad,
-				"13"=>"<img src='../files/usuarios/".$reg->imagen."' height='50px' width='50px' >",
- 				"14"=>($reg->condicion)? '<span>activo</span>' : '<span>Pasivo</span>'		
- 			);		
- 		}
- 		$results = array(
- 			"sEcho"=>1, //Información para el datatables
- 			"iTotalRecords"=>count($data), //enviamos el total registros al datatable
- 			"iTotalDisplayRecords"=>count($data), //enviamos el total registros a visualizar
- 			"aaData"=>$data);
- 		echo json_encode($results);
+        case 'listar':
+                $rspta=$tbl_miembros->listar();
+                //Vamos a declarar un array
+                $data = Array();  //    []
+                // recorremos la tabla de respuestas con un while y dentro una variable reg que toma
+                // el valor de cada una de las rows de rsta
+                while ($reg = $rspta->fetch_object()){
+                         // guardamos en el array data los valores de reg
+                        $data[]=array(
 
-	break;
+                                "0"=>($reg->condicion)? '<button class="btn btn-warning" onclick="mostrar('.$reg->Mi_id.')"><i class="fa fa-edit" style="font-size:24px"></i></button>'.
+                                        ' <button class="btn btn-danger" onclick="desactivar('.$reg->Mi_id.')"> <i class="fa fa-times-rectangle" style="font-size:24px"></i></button>'
+                                         :
+                                        '<button class="btn btn-warning" onclick="mostrar('.$reg->Mi_id.')"><i class="fa fa-edit" style="font-size:24px"></i></button>'.
+                                        ' <button class="btn btn-primary" onclick="activar('.$reg->Mi_id.')"> <i class="fa fa-check-square-o" style="font-size:24px"></i></button>',
+
+                                "1"=>$reg->Mi_Nombres,
+                                "2"=>$reg->Mi_Apellido,
+                                "3"=>$reg->Mi_FechaNacimiento,
+                                "4"=>$reg->Mi_Celular,
+                                "5"=>$reg->Mi_Email,
+                                "6"=>$reg->Ciudad,
+                                "7"=>$reg->Mi_Ocupacion,
+                                "8"=>$reg->Mi_Direccion,
+                                "9"=>$reg->Mi_tiempo,
+                                "10"=>$reg->CI,
+                                "11"=>$reg->EstadoCivil,
+                                "12"=>$reg->CarnetDiscapacidad,
+                                "13"=>"<img src='../files/usuarios/".$reg->imagen."' height='50px' width='50px' >",
+                                "14"=>($reg->condicion)? '<span>activo</span>' : '<span>Pasivo</span>'
+                        );
+                }
+                $results = array(
+                        "sEcho"=>1, //Información para el datatables
+                        "iTotalRecords"=>count($data), //enviamos el total registros al datatable
+                        "iTotalDisplayRecords"=>count($data), //enviamos el total registros a visualizar
+                        "aaData"=>$data);
+                echo json_encode($results);
+
+        break;
+
+        case 'selectEstadoCivil':
+                $rspta=$tbl_miembros->selectEstadoCivil();
+                while ($reg = $rspta->fetch_object())
+                                {
+                                        echo '<option value=' . $reg->id . '>' . $reg->nombre . '</option>';
+                                }
+        break;
+
+        case 'selectDepartamentos':
+                $rspta=$tbl_miembros->selectDepartamentos();
+                while ($reg = $rspta->fetch_object())
+                                {
+                                        echo '<option value=' . $reg->id . '>' . $reg->nombre . '</option>';
+                                }
+        break;
+
+        case 'selectCiudades':
+                $departamento_id = $_GET["departamento_id"];
+                $rspta=$tbl_miembros->selectCiudades($departamento_id);
+                while ($reg = $rspta->fetch_object())
+                                {
+                                        echo '<option value=' . $reg->id . '>' . $reg->nombre . '</option>';
+                                }
+        break;
 }
 ?>

--- a/dbasochipo.sql
+++ b/dbasochipo.sql
@@ -40,6 +40,43 @@ DEFAULT CHARACTER SET = utf8mb4;
 
 
 -- -----------------------------------------------------
+-- Table `dbasochipo`.`tbl_estado_civil`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `dbasochipo`.`tbl_estado_civil` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `nombre` VARCHAR(100) NULL DEFAULT NULL,
+  PRIMARY KEY (`id`))
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = utf8mb4;
+
+-- -----------------------------------------------------
+-- Table `dbasochipo`.`tbl_departamentos`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `dbasochipo`.`tbl_departamentos` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `nombre` VARCHAR(100) NULL DEFAULT NULL,
+  PRIMARY KEY (`id`))
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = utf8mb4;
+
+-- -----------------------------------------------------
+-- Table `dbasochipo`.`tbl_ciudades`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `dbasochipo`.`tbl_ciudades` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `departamento_id` INT(11) NOT NULL,
+  `nombre` VARCHAR(100) NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `fk_ciudad_departamento_idx` (`departamento_id` ASC),
+  CONSTRAINT `fk_ciudad_departamento`
+    FOREIGN KEY (`departamento_id`)
+    REFERENCES `dbasochipo`.`tbl_departamentos` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = utf8mb4;
+
+-- -----------------------------------------------------
 -- Table `dbasochipo`.`tbl_miembros`
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `dbasochipo`.`tbl_miembros` (
@@ -49,16 +86,28 @@ CREATE TABLE IF NOT EXISTS `dbasochipo`.`tbl_miembros` (
   `Mi_FechaNacimiento` DATE NULL DEFAULT NULL,
   `Mi_Celular` VARCHAR(100) NULL DEFAULT NULL,
   `Mi_Email` VARCHAR(100) NULL DEFAULT NULL,
-  `Mi_Departamento` VARCHAR(100) NULL DEFAULT NULL,
+  `ciudad_id` INT(11) NULL DEFAULT NULL,
   `Mi_Ocupacion` VARCHAR(100) NULL DEFAULT NULL,
   `Mi_Direccion` VARCHAR(200) NULL DEFAULT NULL,
   `Mi_tiempo` VARCHAR(50) NULL DEFAULT NULL,
   `CI` VARCHAR(50) NULL DEFAULT NULL,
-  `Civil` VARCHAR(50) NULL DEFAULT NULL,
+  `estado_civil_id` INT(11) NULL DEFAULT NULL,
   `CarnetDiscapacidad` VARCHAR(50) NULL DEFAULT NULL,
   `imagen` VARCHAR(50) NOT NULL,
   `condicion` TINYINT(4) NOT NULL DEFAULT 1,
-  PRIMARY KEY (`Mi_id`))
+  PRIMARY KEY (`Mi_id`),
+  INDEX `fk_miembros_ciudad_idx` (`ciudad_id` ASC),
+  INDEX `fk_miembros_estado_civil_idx` (`estado_civil_id` ASC),
+  CONSTRAINT `fk_miembros_ciudad`
+    FOREIGN KEY (`ciudad_id`)
+    REFERENCES `dbasochipo`.`tbl_ciudades` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_miembros_estado_civil`
+    FOREIGN KEY (`estado_civil_id`)
+    REFERENCES `dbasochipo`.`tbl_estado_civil` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
 ENGINE = InnoDB
 AUTO_INCREMENT = 13
 DEFAULT CHARACTER SET = utf8mb4;

--- a/modelos/tbl_miembros.php
+++ b/modelos/tbl_miembros.php
@@ -8,15 +8,14 @@ Class Tbl_miembros{
     }
 
     // insertar
-    public function insertar($Mi_Nombres,$Mi_Apellido,$Mi_FechaNacimiento,$Mi_Celular,$Mi_Email,$Mi_Departamento,$Mi_Ocupacion,$Mi_Direccion,$Mi_tiempo,$CI,$Civil,$CarnetDiscapacidad,$imagen){     
-        $sql = "INSERT INTO tbl_miembros (Mi_Nombres,Mi_Apellido,Mi_FechaNacimiento,Mi_Celular,Mi_Email,Mi_Departamento,Mi_Ocupacion,Mi_Direccion,Mi_tiempo,CI,Civil,CarnetDiscapacidad,imagen,condicion) VALUES ('$Mi_Nombres','$Mi_Apellido','$Mi_FechaNacimiento','$Mi_Celular','$Mi_Email','$Mi_Departamento','$Mi_Ocupacion','$Mi_Direccion','$Mi_tiempo','$CI','$Civil','$CarnetDiscapacidad','$imagen', '1')";
+    public function insertar($Mi_Nombres,$Mi_Apellido,$Mi_FechaNacimiento,$Mi_Celular,$Mi_Email,$ciudad_id,$Mi_Ocupacion,$Mi_Direccion,$Mi_tiempo,$CI,$estado_civil_id,$CarnetDiscapacidad,$imagen){
+        $sql = "INSERT INTO tbl_miembros (Mi_Nombres,Mi_Apellido,Mi_FechaNacimiento,Mi_Celular,Mi_Email,ciudad_id,Mi_Ocupacion,Mi_Direccion,Mi_tiempo,CI,estado_civil_id,CarnetDiscapacidad,imagen,condicion) VALUES ('$Mi_Nombres','$Mi_Apellido','$Mi_FechaNacimiento','$Mi_Celular','$Mi_Email','$ciudad_id','$Mi_Ocupacion','$Mi_Direccion','$Mi_tiempo','$CI','$estado_civil_id','$CarnetDiscapacidad','$imagen', '1')";
         return ejecutarConsulta($sql);
     }
 
     // editar
-      public function editar($Mi_id,$Mi_Nombres,$Mi_Apellido,$Mi_FechaNacimiento,$Mi_Celular,$Mi_Email,$Mi_Departamento,$Mi_Ocupacion,$Mi_Direccion,$Mi_tiempo,$CI,$Civil,$CarnetDiscapacidad,$imagen){
-        $sql = "UPDATE tbl_miembros SET Mi_Nombres='$Mi_Nombres',Mi_Apellido='$Mi_Apellido',Mi_FechaNacimiento='$Mi_FechaNacimiento',Mi_Celular='$Mi_Celular',Mi_Email='$Mi_Email',Mi_Departamento='$Mi_Departamento',Mi_Ocupacion='$Mi_Ocupacion',Mi_Direccion='$Mi_Direccion',Mi_tiempo='$Mi_tiempo',CI='$CI',Civil='$Civil',CarnetDiscapacidad='$CarnetDiscapacidad',imagen='$imagen' 
-        WHERE Mi_id='$Mi_id'";
+      public function editar($Mi_id,$Mi_Nombres,$Mi_Apellido,$Mi_FechaNacimiento,$Mi_Celular,$Mi_Email,$ciudad_id,$Mi_Ocupacion,$Mi_Direccion,$Mi_tiempo,$CI,$estado_civil_id,$CarnetDiscapacidad,$imagen){
+        $sql = "UPDATE tbl_miembros SET Mi_Nombres='$Mi_Nombres',Mi_Apellido='$Mi_Apellido',Mi_FechaNacimiento='$Mi_FechaNacimiento',Mi_Celular='$Mi_Celular',Mi_Email='$Mi_Email',ciudad_id='$ciudad_id',Mi_Ocupacion='$Mi_Ocupacion',Mi_Direccion='$Mi_Direccion',Mi_tiempo='$Mi_tiempo',CI='$CI',estado_civil_id='$estado_civil_id',CarnetDiscapacidad='$CarnetDiscapacidad',imagen='$imagen' WHERE Mi_id='$Mi_id'";
         return ejecutarConsulta($sql);
         //UPDATE `tbl_miembros` SET `Mi_FechaNacimiento` = '1996-08-03' WHERE `tbl_miembros`.`Mi_id` = 9
     }
@@ -33,22 +32,40 @@ Class Tbl_miembros{
         return ejecutarConsulta($sql);
     }
 
-    // mostrar UN registro 
+    // mostrar UN registro
     public function mostrar($Mi_id){
-        $sql = "SELECT * FROM tbl_miembros WHERE Mi_id='$Mi_id'";
+        $sql = "SELECT m.*, c.departamento_id FROM tbl_miembros m LEFT JOIN tbl_ciudades c ON m.ciudad_id=c.id WHERE Mi_id='$Mi_id'";
         return ejecutarConsultaSimpleFila($sql);
     }
 
-    // listar TODOS los registros 
+    // listar TODOS los registros
     public function listar(){
-        $sql = "SELECT * FROM tbl_miembros";
+        $sql = "SELECT m.*, c.nombre AS Ciudad, d.nombre AS Departamento, e.nombre AS EstadoCivil FROM tbl_miembros m LEFT JOIN tbl_ciudades c ON m.ciudad_id=c.id LEFT JOIN tbl_departamentos d ON c.departamento_id=d.id LEFT JOIN tbl_estado_civil e ON m.estado_civil_id=e.id";
         return ejecutarConsulta($sql);
     }
 
     public function select()
-	{
-		$sql="SELECT * FROM tbl_miembros WHERE condicion=1";
-		return ejecutarConsulta($sql);		
-	}
+        {
+                $sql="SELECT * FROM tbl_miembros WHERE condicion=1";
+                return ejecutarConsulta($sql);
+        }
+
+    public function selectEstadoCivil()
+        {
+                $sql="SELECT * FROM tbl_estado_civil";
+                return ejecutarConsulta($sql);
+        }
+
+    public function selectDepartamentos()
+        {
+                $sql="SELECT * FROM tbl_departamentos";
+                return ejecutarConsulta($sql);
+        }
+
+    public function selectCiudades($departamento_id)
+        {
+                $sql="SELECT * FROM tbl_ciudades WHERE departamento_id='$departamento_id'";
+                return ejecutarConsulta($sql);
+        }
 }
 ?>

--- a/vistas/scripts/tbl_miembros.js
+++ b/vistas/scripts/tbl_miembros.js
@@ -10,7 +10,24 @@ function init(){
     });
 
     $("#imagenmuestra").hide();
-    
+
+    $.post("../ajax/tbl_miembros.php?op=selectEstadoCivil", function(r){
+        $("#estado_civil_id").html(r);
+        $('#estado_civil_id').selectpicker('refresh');
+    });
+
+    $.post("../ajax/tbl_miembros.php?op=selectDepartamentos", function(r){
+        $("#departamento_id").html(r);
+        $('#departamento_id').selectpicker('refresh');
+    });
+
+    $("#departamento_id").on('change', function(){
+        var id = $(this).val();
+        $.post("../ajax/tbl_miembros.php?op=selectCiudades&departamento_id="+id, function(r){
+            $("#ciudad_id").html(r);
+            $('#ciudad_id').selectpicker('refresh');
+        });
+    });
 }
 
 function limpiar(){
@@ -20,12 +37,20 @@ function limpiar(){
     $("#Mi_FechaNacimiento").val("");
 	$("#Mi_Celular").val("");
 	$("#Mi_Email").val("");
-	$("#Mi_Ocupacion").val("");
-	$("#Mi_Direccion").val("");
-	$("#Mi_tiempo").val("");
-	$("#CI").val("");
-	$("#imagenmuestra").attr("src","");
-	$("#imagenactual").val("");
+    $("#Mi_Ocupacion").val("");
+        $("#Mi_Direccion").val("");
+        $("#Mi_tiempo").val("");
+        $("#CI").val("");
+        $("#departamento_id").val("");
+        $('#departamento_id').selectpicker('refresh');
+        $("#ciudad_id").val("");
+        $('#ciudad_id').selectpicker('refresh');
+        $("#estado_civil_id").val("");
+        $('#estado_civil_id').selectpicker('refresh');
+        $("#CarnetDiscapacidad").val("");
+        $('#CarnetDiscapacidad').selectpicker('refresh');
+        $("#imagenmuestra").attr("src","");
+        $("#imagenactual").val("");
 }
 
 function mostrarform(flag){
@@ -107,19 +132,24 @@ function mostrar(Mi_id){
 		$("#Mi_FechaNacimiento").selectpicker('refresh');
 		$("#Mi_Celular").val(data.Mi_Celular);
 		$("#Mi_Email").val(data.Mi_Email);
-		$("#Mi_Departamento").val(data.Mi_Departamento);
-		$("#Mi_Departamento").selectpicker('refresh');
-		$("#Mi_Ocupacion").val(data.Mi_Ocupacion);
-		$("#Mi_Direccion").val(data.Mi_Direccion);
-		$("#Mi_tiempo").val(data.Mi_tiempo);
-		$("#CI").val(data.CI);
-		$("#Civil").val(data.Civil);
-		$("#Civil").selectpicker('refresh');
-		$("#CarnetDiscapacidad").val(data.CarnetDiscapacidad);
-		$("#CarnetDiscapacidad").selectpicker('refresh');
-		$("#imagenmuestra").show();
-		$("#imagenmuestra").attr("src","../files/usuarios/"+data.imagen);
-		$("#imagenactual").val(data.imagen);
+                $("#departamento_id").val(data.departamento_id);
+                $('#departamento_id').selectpicker('refresh');
+                $.post("../ajax/tbl_miembros.php?op=selectCiudades&departamento_id="+data.departamento_id,function(r){
+                        $("#ciudad_id").html(r);
+                        $('#ciudad_id').val(data.ciudad_id);
+                        $('#ciudad_id').selectpicker('refresh');
+                });
+                $("#Mi_Ocupacion").val(data.Mi_Ocupacion);
+                $("#Mi_Direccion").val(data.Mi_Direccion);
+                $("#Mi_tiempo").val(data.Mi_tiempo);
+                $("#CI").val(data.CI);
+                $("#estado_civil_id").val(data.estado_civil_id);
+                $('#estado_civil_id').selectpicker('refresh');
+                $("#CarnetDiscapacidad").val(data.CarnetDiscapacidad);
+                $('#CarnetDiscapacidad').selectpicker('refresh');
+                $("#imagenmuestra").show();
+                $("#imagenmuestra").attr("src","../files/usuarios/"+data.imagen);
+                $("#imagenactual").val(data.imagen);
     })
 }
 

--- a/vistas/tbl_miembros.php
+++ b/vistas/tbl_miembros.php
@@ -49,12 +49,12 @@ require 'header.php';
                             <th>Fecha de<p>Nacimiento</p></th>
                             <th>Celular</th>
                             <th>Email</th>
-                            <th>Departamento</th>
+                            <th>Ciudad</th>
                             <th>Ocupacion</th>
                             <th>Direccion</th>
                             <th>Tiempo</th>
                             <th>CI</th>
-                            <th>Civil</th>
+                            <th>Estado Civil</th>
                             <th>Carnet <p>Discapacidad</p></th>
                             <th>Foto</th>
                             <th>Estado</th>
@@ -68,12 +68,12 @@ require 'header.php';
                             <th>Fecha de<p>Nacimiento</p></th>
                             <th>Celular</th>
                             <th>Email</th>
-                            <th>Departamento</th>
+                            <th>Ciudad</th>
                             <th>Ocupacion</th>
                             <th>Direccion</th>
                             <th>Tiempo</th>
                             <th>CI</th>
-                            <th>Civil</th>
+                            <th>Estado Civil</th>
                             <th>Carnet <p>Discapacidad</p></th>
                             <th>Foto</th>
                             <th>Estado</th>
@@ -116,17 +116,13 @@ require 'header.php';
 
                           <div class="form-group col-lg-6 col-md-6 col-sm-6 col-xs-12">
                             <label>Departamento:</label>
-                            <select class="form-control select-picker" name="Mi_Departamento" id="Mi_Departamento">
-                              <option selected>Seleccionar departamento</option>  
-                              <option value="La Paz">La Paz</option>
-                              <option value="Oruro">Oruro</option>
-                              <option value="Potosi">Potosi</option>
-                              <option value="Cochabamba">Cochabamba</option>
-                              <option value="Chuquisaca">Chuquisaca</option>
-                              <option value="Tarija">Tarija</option>
-                              <option value="Pando">Pando</option>
-                              <option value="Beni">Beni</option>
-                              <option value="Santa Cruz">Santa Cruz</option>
+                            <select class="form-control select-picker" name="departamento_id" id="departamento_id">
+                            </select>
+                          </div>
+
+                          <div class="form-group col-lg-6 col-md-6 col-sm-6 col-xs-12">
+                            <label>Ciudad:</label>
+                            <select class="form-control select-picker" name="ciudad_id" id="ciudad_id">
                             </select>
                           </div>
 
@@ -152,12 +148,7 @@ require 'header.php';
 
                           <div class="form-group col-lg-6 col-md-6 col-sm-6 col-xs-12">
                             <label>Estado Civil:</label>
-                            <select class="form-control select-picker" name="Civil" id="Civil">
-                              <option selected>Seleccionar estado Civil</option> 
-                              <option value="Soltero/a">Soltero/a</option>
-                              <option value="Casado/a">Casado/a</option>
-                              <option value="Divorciado/a">Divorciado/a</option>
-                              <option value="Otros">Otros</option>
+                            <select class="form-control select-picker" name="estado_civil_id" id="estado_civil_id">
                             </select>
                           </div>
 


### PR DESCRIPTION
## Summary
- add parametric tables for civil status, departments and cities
- link miembros to new tables via foreign keys
- load civil status and city options dynamically in miembros forms

## Testing
- `php -l modelos/tbl_miembros.php`
- `php -l ajax/tbl_miembros.php`
- `php -l vistas/tbl_miembros.php`


------
https://chatgpt.com/codex/tasks/task_e_68af40b8cf988321905aa141682695e8