### PR TITLE
Normalize status to Activo/Inactivo

### DIFF
--- a/ajax/articulo.php
+++ b/ajax/articulo.php
@@ -45,17 +45,17 @@ switch ($_GET["op"]){
 		}
 	break;
 
-	case 'desactivar':
-		$rspta=$articulo->desactivar($idarticulo);
- 		echo $rspta ? "Artículo Desactivado" : "Artículo no se puede desactivar";
- 		break;
-	break;
+        case 'desactivar':
+                $rspta=$articulo->desactivar($idarticulo);
+                echo $rspta ? "Artículo inactivo" : "Artículo no se puede inactivar";
+                break;
+        break;
 
-	case 'activar':
-		$rspta=$articulo->activar($idarticulo);
- 		echo $rspta ? "Artículo activado" : "Artículo no se puede activar";
- 		break;
-	break;
+        case 'activar':
+                $rspta=$articulo->activar($idarticulo);
+                echo $rspta ? "Artículo activo" : "Artículo no se puede activar";
+                break;
+        break;
 
 	case 'mostrar':
 		$rspta=$articulo->mostrar($idarticulo);
@@ -72,17 +72,17 @@ switch ($_GET["op"]){
  		while ($reg=$rspta->fetch_object()){
  			$data[]=array(
  				"0"=>($reg->condicion)?'<button class="btn btn-warning" onclick="mostrar('.$reg->idarticulo.')">editar</button>'.
- 					' <button class="btn btn-danger" onclick="desactivar('.$reg->idarticulo.')">desactivar</button>'
+ 					' <button class="btn btn-danger" onclick="desactivar('.$reg->idarticulo.')">Inactivar</button>'
 					 :
  					'<button class="btn btn-warning" onclick="mostrar('.$reg->idarticulo.')">editar</button>'.
- 					' <button class="btn btn-primary" onclick="activar('.$reg->idarticulo.')">activar</button>',
+ 					' <button class="btn btn-primary" onclick="activar('.$reg->idarticulo.')">Activar</button>',
  				"1"=>$reg->nombre,
  				"2"=>$reg->categoria,
  				"3"=>$reg->codigo,
  				"4"=>$reg->stock,
  				"5"=>"<img src='../files/articulos/".$reg->imagen."' height='50px' width='50px' >",
 				//"5"=>$reg->imagen,
- 				"6"=>($reg->condicion)?'<span>Activado</span>':'<span>Desactivado</span>'
+ 				"6"=>($reg->condicion)?'<span>Activo</span>':'<span>Inactivo</span>'
  				);
  		}
  		$results = array(

--- a/ajax/categoria.php
+++ b/ajax/categoria.php
@@ -24,17 +24,17 @@ switch ($_GET["op"]){
 		}
 	break;
 
-	case 'desactivar':
-		// cambiamos a 0 el estado con el metodo definido
-		$rspta = $categoria->desactivar($idcategoria);
- 		echo $rspta ? "Categoría Desactivada" : "Categoría no se puede desactivar";
-	break;
+        case 'desactivar':
+                // cambiamos a Inactivo el estado con el metodo definido
+                $rspta = $categoria->desactivar($idcategoria);
+                echo $rspta ? "Categoría inactiva" : "Categoría no se puede inactivar";
+        break;
 
-	case 'activar':
-		// cambiamos a 1 el estado con el metodo definido
-		$rspta = $categoria->activar($idcategoria);
- 		echo $rspta ? "Categoría activada" : "Categoría no se puede activar";
-	break;
+        case 'activar':
+                // cambiamos a Activo el estado con el metodo definido
+                $rspta = $categoria->activar($idcategoria);
+                echo $rspta ? "Categoría activa" : "Categoría no se puede activar";
+        break;
 
 	case 'mostrar':
 		$rspta = $categoria->mostrar($idcategoria);
@@ -61,10 +61,10 @@ switch ($_GET["op"]){
 			$data[]=array(
 				
  				"0"=>($reg->condicion)? '<button class="btn btn-warning" onclick="mostrar('.$reg->idcategoria.')">editar</button>'.
- 					' <button class="btn btn-danger" onclick="desactivar('.$reg->idcategoria.')">desactivar</button>' 
+ 					' <button class="btn btn-danger" onclick="desactivar('.$reg->idcategoria.')">Inactivar</button>' 
 					 :
  					'<button class="btn btn-warning" onclick="mostrar('.$reg->idcategoria.')">editar</button>'.
- 					' <button class="btn btn-primary" onclick="activar('.$reg->idcategoria.')">activar</button>',
+ 					' <button class="btn btn-primary" onclick="activar('.$reg->idcategoria.')">Activar</button>',
 
 				// "0"=>'<button class="btn btn-warning" onclick="mostrar(' . $reg->idcategoria . ')">editar</button>'
 				// .' <button class="btn btn-danger" onclick="desactivar('.$reg->idcategoria.')">descativar</button>'
@@ -72,7 +72,7 @@ switch ($_GET["op"]){
 				
 				"1"=>$reg->nombre,
  				"2"=>$reg->descripcion,
- 				"3"=>($reg->condicion)? '<span>activado</span>' : '<span>desactivado</span>'
+ 				"3"=>($reg->condicion)? '<span>Activo</span>' : '<span>Inactivo</span>'
 				
  			);
 		

--- a/ajax/tbl_apoyo_miembros.php
+++ b/ajax/tbl_apoyo_miembros.php
@@ -23,17 +23,17 @@ switch ($_GET["op"]){
 		}
 	break;
 
-	case 'desactivar':
-		$rspta=$tbl_apoyo_miembros->desactivar($ApoMi_id);
- 		echo $rspta ? "Tipo de ayuda Desactivada" : "Tipo de ayuda no se puede desactivar";
- 		break;
-	break;
+        case 'desactivar':
+                $rspta=$tbl_apoyo_miembros->desactivar($ApoMi_id);
+                echo $rspta ? "Tipo de ayuda inactiva" : "Tipo de ayuda no se puede inactivar";
+                break;
+        break;
 
-	case 'activar':
-		$rspta=$tbl_apoyo_miembros->activar($ApoMi_id);
- 		echo $rspta ? "Tipo de ayuda activada" : "Tipo de ayuda no se puede activar";
- 		break;
-	break;
+        case 'activar':
+                $rspta=$tbl_apoyo_miembros->activar($ApoMi_id);
+                echo $rspta ? "Tipo de ayuda activa" : "Tipo de ayuda no se puede activar";
+                break;
+        break;
 
 	case 'mostrar':
 		$rspta=$tbl_apoyo_miembros->mostrar($ApoMi_id);
@@ -59,8 +59,8 @@ switch ($_GET["op"]){
  				"3"=>$reg->ApoMi_Cantidad,
  				"4"=>$reg->ApoMi_Observaciones,
 				"5"=>$reg->ApoMi_registro,
- 				"6"=>($reg->condicion)?'<span>Activado</span>':'<span>Desactivado</span>'
- 				);
+                                "6"=>($reg->condicion)?'<span>Activo</span>':'<span>Inactivo</span>'
+                                );
  		}
  		$results = array(
  			"sEcho"=>1, //Información para el datatables

--- a/ajax/tbl_auspiciantes.php
+++ b/ajax/tbl_auspiciantes.php
@@ -41,17 +41,17 @@ switch ($_GET["op"]){
 		}
 	break;
 
-	case 'desactivar':
-		// cambiamos a 0 el estado con el metodo definido
-		$rspta = $tbl_auspiciantes->desactivar($aus_id);
- 		echo $rspta ? "Auspiciante Desactivado" : "Auspiciante no se puede desactivar";
-	break;
+        case 'desactivar':
+                // cambiamos a Inactivo el estado con el metodo definido
+                $rspta = $tbl_auspiciantes->desactivar($aus_id);
+                echo $rspta ? "Auspiciante inactivo" : "Auspiciante no se puede inactivar";
+        break;
 
-	case 'activar':
-		// cambiamos a 1 el estado con el metodo definido
-		$rspta = $tbl_auspiciantes->activar($aus_id);
- 		echo $rspta ? "Auspiciante activado" : "Auspiciante no se puede activar";
-	break;
+        case 'activar':
+                // cambiamos a Activo el estado con el metodo definido
+                $rspta = $tbl_auspiciantes->activar($aus_id);
+                echo $rspta ? "Auspiciante activo" : "Auspiciante no se puede activar";
+        break;
 
 	case 'mostrar':
 		$rspta = $tbl_auspiciantes->mostrar($aus_id);
@@ -83,8 +83,8 @@ switch ($_GET["op"]){
 					"4"=>$reg->aus_ciudad,
 					"5"=>$reg->Otro_dato,
 					"6"=>"<img src='../files/auspiciantes/".$reg->imagen."' height='50px' width='50px' >",
-					"7"=>($reg->condicion)? '<span>activado</span>' : '<span>desactivado</span>'
- 			);
+                                        "7"=>($reg->condicion)? '<span>Activo</span>' : '<span>Inactivo</span>'
+                        );
 		
  		}
  		$results = array(

--- a/ajax/tbl_mesa_directiva.php
+++ b/ajax/tbl_mesa_directiva.php
@@ -43,15 +43,15 @@ switch ($_GET["op"]){
 		}
 	break;
 
-	case 'desactivar':
-		$rspta=$tbl_mesa_directiva->desactivar($MeDi_id);
- 		echo $rspta ? "Usuario Desactivado" : "Usuario no se puede desactivar";
-	break;
+        case 'desactivar':
+                $rspta=$tbl_mesa_directiva->desactivar($MeDi_id);
+                echo $rspta ? "Usuario inactivo" : "Usuario no se puede inactivar";
+        break;
 
-	case 'activar':
-		$rspta=$tbl_mesa_directiva->activar($MeDi_id);
- 		echo $rspta ? "Usuario activado" : "Usuario no se puede activar";
-	break;
+        case 'activar':
+                $rspta=$tbl_mesa_directiva->activar($MeDi_id);
+                echo $rspta ? "Usuario activo" : "Usuario no se puede activar";
+        break;
 
 	//editar
 	case 'mostrar':
@@ -68,19 +68,18 @@ switch ($_GET["op"]){
  		while ($reg=$rspta->fetch_object()){
  			$data[]=array(
  				"0"=>($reg->condicion)?'<button class="btn btn-warning" onclick="mostrar('.$reg->MeDi_id.')">editar</button>'.
- 					' <button class="btn btn-danger" onclick="desactivar('.$reg->MeDi_id.')">descativar</button>':
+ 					' <button class="btn btn-danger" onclick="desactivar('.$reg->MeDi_id.')">Inactivar</button>':
  					'<button class="btn btn-warning" onclick="mostrar('.$reg->MeDi_id.')">editar</button>'.
- 					' <button class="btn btn-primary" onclick="activar('.$reg->MeDi_id.')">activar</button>',
+ 					' <button class="btn btn-primary" onclick="activar('.$reg->MeDi_id.')">Activar</button>',
  				"1"=>$reg->tbl_miembros,
  				"2"=>$reg->cargo,
  				"3"=>$reg->MeDi_FechaInicioFunciones,
  				"4"=>$reg->login,
  				"5"=>"<img src='../files/usuarios/".$reg->imagen."' height='50px' width='50px' >",
 				//"7"=>$reg->imagen,
- 				//"6"=>($reg->condicion)?'<span class="label bg-green">Activado</span>':
- 				'<span class="label bg-red">Desactivado</span>'
- 				);
- 		}
+                                "6"=>($reg->condicion)?'<span>Activo</span>':'<span>Inactivo</span>'
+                                );
+                }
  		$results = array(
  			"sEcho"=>1, //Información para el datatables
  			"iTotalRecords"=>count($data), //enviamos el total registros al datatable

--- a/ajax/tbl_miembros.php
+++ b/ajax/tbl_miembros.php
@@ -50,15 +50,15 @@ switch ($_GET["op"]){
         break;
 
         case 'desactivar':
-                // cambiamos a 0 el estado con el metodo definido
+                // cambiamos a Inactivo el estado con el metodo definido
                 $rspta = $tbl_miembros->desactivar($Mi_id);
-                echo $rspta ? "Usuario pasivo" : "Usuario no se puede desactivar";
+                echo $rspta ? "Miembro inactivo" : "Miembro no se puede inactivar";
         break;
 
         case 'activar':
-                // cambiamos a 1 el estado con el metodo definido
+                // cambiamos a Activo el estado con el metodo definido
                 $rspta = $tbl_miembros->activar($Mi_id);
-                echo $rspta ? "Usuario activo" : "Us no se puede activar";
+                echo $rspta ? "Miembro activo" : "Miembro no se puede activar";
         break;
 
         case 'mostrar':
@@ -78,7 +78,7 @@ switch ($_GET["op"]){
                          // guardamos en el array data los valores de reg
                         $data[]=array(
 
-                                "0"=>($reg->condicion)? '<button class="btn btn-warning" onclick="mostrar('.$reg->Mi_id.')"><i class="fa fa-edit" style="font-size:24px"></i></button>'.
+                                "0"=>($reg->Mi_Estado=='Activo')? '<button class="btn btn-warning" onclick="mostrar('.$reg->Mi_id.')"><i class="fa fa-edit" style="font-size:24px"></i></button>'.
                                         ' <button class="btn btn-danger" onclick="desactivar('.$reg->Mi_id.')"> <i class="fa fa-times-rectangle" style="font-size:24px"></i></button>'
                                          :
                                         '<button class="btn btn-warning" onclick="mostrar('.$reg->Mi_id.')"><i class="fa fa-edit" style="font-size:24px"></i></button>'.
@@ -97,7 +97,7 @@ switch ($_GET["op"]){
                                 "11"=>$reg->EstadoCivil,
                                 "12"=>$reg->CarnetDiscapacidad,
                                 "13"=>"<img src='../files/usuarios/".$reg->imagen."' height='50px' width='50px' >",
-                                "14"=>($reg->condicion)? '<span>activo</span>' : '<span>Pasivo</span>'
+                                "14"=>($reg->Mi_Estado=='Activo')? '<span>Activo</span>' : '<span>Inactivo</span>'
                         );
                 }
                 $results = array(

--- a/ajax/usuario.php
+++ b/ajax/usuario.php
@@ -48,15 +48,15 @@ switch ($_GET["op"]){
 		}
 	break;
 
-	case 'desactivar':
-		$rspta=$usuario->desactivar($idusuario);
- 		echo $rspta ? "Usuario Desactivado" : "Usuario no se puede desactivar";
-	break;
+        case 'desactivar':
+                $rspta=$usuario->desactivar($idusuario);
+                echo $rspta ? "Usuario inactivo" : "Usuario no se puede inactivar";
+        break;
 
-	case 'activar':
-		$rspta=$usuario->activar($idusuario);
- 		echo $rspta ? "Usuario activado" : "Usuario no se puede activar";
-	break;
+        case 'activar':
+                $rspta=$usuario->activar($idusuario);
+                echo $rspta ? "Usuario activo" : "Usuario no se puede activar";
+        break;
 
 	//editar
 	case 'mostrar':
@@ -72,10 +72,10 @@ switch ($_GET["op"]){
 
  		while ($reg=$rspta->fetch_object()){
  			$data[]=array(
- 				"0"=>($reg->condicion)?'<button class="btn btn-warning" onclick="mostrar('.$reg->idusuario.')">editar</button>'.
- 					' <button class="btn btn-danger" onclick="desactivar('.$reg->idusuario.')">descativar</button>':
- 					'<button class="btn btn-warning" onclick="mostrar('.$reg->idusuario.')">editar</button>'.
- 					' <button class="btn btn-primary" onclick="activar('.$reg->idusuario.')">activar</button>',
+                                "0"=>($reg->condicion)?'<button class="btn btn-warning" onclick="mostrar('.$reg->idusuario.')">editar</button>'.
+                                        ' <button class="btn btn-danger" onclick="desactivar('.$reg->idusuario.')">Inactivar</button>':
+                                        '<button class="btn btn-warning" onclick="mostrar('.$reg->idusuario.')">editar</button>'.
+                                        ' <button class="btn btn-primary" onclick="activar('.$reg->idusuario.')">Activar</button>',
  				"1"=>$reg->nombre,
  				"2"=>$reg->tipo_documento,
  				"3"=>$reg->num_documento,
@@ -84,8 +84,8 @@ switch ($_GET["op"]){
  				"6"=>$reg->login,
  				"7"=>"<img src='../files/usuarios/".$reg->imagen."' height='50px' width='50px' >",
 				//"7"=>$reg->imagen,
- 				"8"=>($reg->condicion)?'<span class="label bg-green">Activado</span>':
- 				'<span class="label bg-red">Desactivado</span>'
+                                "8"=>($reg->condicion)?'<span class="label bg-green">Activo</span>':
+                                '<span class="label bg-red">Inactivo</span>'
  				);
  		}
  		$results = array(

--- a/dbasochipo.sql
+++ b/dbasochipo.sql
@@ -94,7 +94,7 @@ CREATE TABLE IF NOT EXISTS `dbasochipo`.`tbl_miembros` (
   `estado_civil_id` INT(11) NULL DEFAULT NULL,
   `CarnetDiscapacidad` VARCHAR(50) NULL DEFAULT NULL,
   `imagen` VARCHAR(50) NOT NULL,
-  `condicion` TINYINT(4) NOT NULL DEFAULT 1,
+  `Mi_Estado` ENUM('Activo','Inactivo') NOT NULL DEFAULT 'Activo',
   PRIMARY KEY (`Mi_id`),
   INDEX `fk_miembros_ciudad_idx` (`ciudad_id` ASC),
   INDEX `fk_miembros_estado_civil_idx` (`estado_civil_id` ASC),

--- a/modelos/tbl_miembros.php
+++ b/modelos/tbl_miembros.php
@@ -9,7 +9,7 @@ Class Tbl_miembros{
 
     // insertar
     public function insertar($Mi_Nombres,$Mi_Apellido,$Mi_FechaNacimiento,$Mi_Celular,$Mi_Email,$ciudad_id,$Mi_Ocupacion,$Mi_Direccion,$Mi_tiempo,$CI,$estado_civil_id,$CarnetDiscapacidad,$imagen){
-        $sql = "INSERT INTO tbl_miembros (Mi_Nombres,Mi_Apellido,Mi_FechaNacimiento,Mi_Celular,Mi_Email,ciudad_id,Mi_Ocupacion,Mi_Direccion,Mi_tiempo,CI,estado_civil_id,CarnetDiscapacidad,imagen,condicion) VALUES ('$Mi_Nombres','$Mi_Apellido','$Mi_FechaNacimiento','$Mi_Celular','$Mi_Email','$ciudad_id','$Mi_Ocupacion','$Mi_Direccion','$Mi_tiempo','$CI','$estado_civil_id','$CarnetDiscapacidad','$imagen', '1')";
+        $sql = "INSERT INTO tbl_miembros (Mi_Nombres,Mi_Apellido,Mi_FechaNacimiento,Mi_Celular,Mi_Email,ciudad_id,Mi_Ocupacion,Mi_Direccion,Mi_tiempo,CI,estado_civil_id,CarnetDiscapacidad,imagen,Mi_Estado) VALUES ('$Mi_Nombres','$Mi_Apellido','$Mi_FechaNacimiento','$Mi_Celular','$Mi_Email','$ciudad_id','$Mi_Ocupacion','$Mi_Direccion','$Mi_tiempo','$CI','$estado_civil_id','$CarnetDiscapacidad','$imagen','Activo')";
         return ejecutarConsulta($sql);
     }
 
@@ -20,15 +20,15 @@ Class Tbl_miembros{
         //UPDATE `tbl_miembros` SET `Mi_FechaNacimiento` = '1996-08-03' WHERE `tbl_miembros`.`Mi_id` = 9
     }
 
-    // eliminar = desactivar osea condicion = 0
+    // cambiar estado a Inactivo
     public function desactivar($Mi_id){
-        $sql = "UPDATE tbl_miembros SET condicion='0' WHERE Mi_id='$Mi_id'";
+        $sql = "UPDATE tbl_miembros SET Mi_Estado='Inactivo' WHERE Mi_id='$Mi_id'";
         return ejecutarConsulta($sql);
     }
 
-    // activar = activar osea condicion = 1
+    // cambiar estado a Activo
     public function activar($Mi_id){
-        $sql = "UPDATE tbl_miembros SET condicion='1' WHERE Mi_id='$Mi_id'";
+        $sql = "UPDATE tbl_miembros SET Mi_Estado='Activo' WHERE Mi_id='$Mi_id'";
         return ejecutarConsulta($sql);
     }
 
@@ -46,7 +46,7 @@ Class Tbl_miembros{
 
     public function select()
         {
-                $sql="SELECT * FROM tbl_miembros WHERE condicion=1";
+                $sql="SELECT * FROM tbl_miembros WHERE Mi_Estado='Activo'";
                 return ejecutarConsulta($sql);
         }
 

--- a/vistas/scripts/articulo.js
+++ b/vistas/scripts/articulo.js
@@ -128,7 +128,7 @@ function mostrar(idarticulo){
 }
 
 function desactivar(idarticulo){
-    var opcion = confirm("¿Está Seguro de desactivar la artículo?");
+    var opcion = confirm("¿Está Seguro de inactivar el artículo?");
 	//confirm("¿Está Seguro de desactivar el artículo?", function(result){
 		if(opcion)
         {

--- a/vistas/scripts/categoria.js
+++ b/vistas/scripts/categoria.js
@@ -99,7 +99,7 @@ function mostrar(idcategoria){
 }
 
 function desactivar(idcategoria){
-    var opcion = confirm("¿Está Seguro de desactivar la Categoría?");
+    var opcion = confirm("¿Está Seguro de inactivar la Categoría?");
     if(opcion) 		// entra solo si da ACEPTAR
     {
         $.post("../ajax/categoria.php?op=desactivar", {idcategoria : idcategoria}, function(e){

--- a/vistas/scripts/tbl_apoyo_miembros.js
+++ b/vistas/scripts/tbl_apoyo_miembros.js
@@ -117,7 +117,7 @@ function mostrar(ApoMi_id){
 }
 
 function desactivar(ApoMi_id){
-    var opcion = confirm("¿Está seguro de DESACTIVAR el usuario?");
+    var opcion = confirm("¿Está seguro de INACTIVAR el usuario?");
 	//confirm("¿Está Seguro de desactivar el usuario?", function(result){
 		if(opcion)
         {

--- a/vistas/scripts/tbl_auspiciantes.js
+++ b/vistas/scripts/tbl_auspiciantes.js
@@ -111,7 +111,7 @@ function mostrar(aus_id){
 }
 
 function desactivar(aus_id){
-    var opcion = confirm("¿Está Seguro de desactivar este auspiciantes?");
+    var opcion = confirm("¿Está Seguro de inactivar este auspiciantes?");
     if(opcion) 		// entra solo si da ACEPTAR
     {
         $.post("../ajax/tbl_auspiciantes.php?op=desactivar", {aus_id : aus_id}, function(e){

--- a/vistas/scripts/tbl_mesa_directiva.js
+++ b/vistas/scripts/tbl_mesa_directiva.js
@@ -148,7 +148,7 @@ function mostrar(MeDi_id)
 //Función para desactivar registros
 function desactivar(MeDi_id)
 {
-	var opcion = confirm("¿Está Seguro de desactivar el Usuario?");
+    var opcion = confirm("¿Está Seguro de inactivar el Usuario?");
 //	confirm("¿Está Seguro de desactivar el usuario?", function(result){
 		if(opcion)
         {

--- a/vistas/scripts/tbl_miembros.js
+++ b/vistas/scripts/tbl_miembros.js
@@ -154,7 +154,7 @@ function mostrar(Mi_id){
 }
 
 function desactivar(Mi_id){
-    var opcion = confirm("¿Está Seguro de desactivar este usuario?");
+    var opcion = confirm("¿Está Seguro de inactivar este usuario?");
     if(opcion) 		// entra solo si da ACEPTAR
     {
         $.post("../ajax/tbl_miembros.php?op=desactivar", {Mi_id : Mi_id}, function(e){

--- a/vistas/scripts/usuario.js
+++ b/vistas/scripts/usuario.js
@@ -147,7 +147,7 @@ function mostrar(idusuario)
 //Función para desactivar registros
 function desactivar(idusuario)
 {
-	var opcion = confirm("¿Está Seguro de desactivar el Usuario?");
+	var opcion = confirm("¿Está Seguro de inactivar el Usuario?");
 //	confirm("¿Está Seguro de desactivar el usuario?", function(result){
 		if(opcion)
         {


### PR DESCRIPTION
## Summary
- Define `Mi_Estado` enum in `tbl_miembros` and update PHP model for state changes
- Standardize AJAX responses and JS prompts to use "Activo"/"Inactivo"
- Apply the same terminology across other modules with `condicion`

## Testing
- `php -l ajax/articulo.php`
- `php -l ajax/categoria.php`
- `php -l ajax/tbl_apoyo_miembros.php`
- `php -l ajax/tbl_auspiciantes.php`
- `php -l ajax/tbl_mesa_directiva.php`
- `php -l ajax/tbl_miembros.php`
- `php -l ajax/usuario.php`
- `php -l modelos/tbl_miembros.php`
- `node --check vistas/scripts/articulo.js`
- `node --check vistas/scripts/categoria.js`
- `node --check vistas/scripts/tbl_apoyo_miembros.js`
- `node --check vistas/scripts/tbl_auspiciantes.js`
- `node --check vistas/scripts/tbl_mesa_directiva.js`
- `node --check vistas/scripts/tbl_miembros.js`
- `node --check vistas/scripts/usuario.js`


------
https://chatgpt.com/codex/tasks/task_e_68af43bb0ff483218e886e55789210a6