### PR TITLE
Agregar sistema de alertas de vencimientos y eventos

### DIFF
--- a/ajax/alertas.php
+++ b/ajax/alertas.php
@@ -1,0 +1,15 @@
+<?php
+require_once "../modelos/Alertas.php";
+
+$alerta = new Alertas();
+
+switch ($_GET["op"]) {
+    case 'marcar':
+        $id = intval($_GET['id']);
+        $alerta->marcarLeida($id);
+        header('Location: ../vistas/escritorio.php');
+    break;
+}
+
+?>
+

--- a/cron/alertas.php
+++ b/cron/alertas.php
@@ -1,0 +1,31 @@
+<?php
+require_once "../modelos/Alertas.php";
+require_once "../config/Conexion.php";
+
+$alerta = new Alertas();
+
+$hoy = date('Y-m-d');
+$limite = date('Y-m-d', strtotime('+7 days'));
+
+// Cuotas pendientes próximas
+$sql = "SELECT MeDi_id, DATE(Cuo_fechaPago) AS fecha FROM tbl_cuotas WHERE Cuo_Pagado = 0 AND DATE(Cuo_fechaPago) BETWEEN '$hoy' AND '$limite'";
+$cuotas = ejecutarConsulta($sql);
+while ($c = $cuotas->fetch_assoc()) {
+    $existe = $alerta->existe('cuota', $c['MeDi_id'], $c['fecha']);
+    if ($existe->num_rows == 0) {
+        $alerta->insertar('cuota', $c['MeDi_id'], $c['fecha']);
+    }
+}
+
+// Actividades próximas
+$sql = "SELECT MeDi_id, DATE(Act_fecha) AS fecha FROM tbl_actividades WHERE DATE(Act_fecha) BETWEEN '$hoy' AND '$limite'";
+$actividades = ejecutarConsulta($sql);
+while ($a = $actividades->fetch_assoc()) {
+    $existe = $alerta->existe('actividad', $a['MeDi_id'], $a['fecha']);
+    if ($existe->num_rows == 0) {
+        $alerta->insertar('actividad', $a['MeDi_id'], $a['fecha']);
+    }
+}
+
+?>
+

--- a/dbasochipo.sql
+++ b/dbasochipo.sql
@@ -364,11 +364,11 @@ ENGINE = InnoDB;
 
 
 -- -----------------------------------------------------
--- Table `dbasochipo`.`usuario_permiso`
--- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `dbasochipo`.`usuario_permiso` (
-  `idusuario_permiso` INT NOT NULL,
-  `MeDi_id` INT NOT NULL,
+  -- Table `dbasochipo`.`usuario_permiso`
+  -- -----------------------------------------------------
+  CREATE TABLE IF NOT EXISTS `dbasochipo`.`usuario_permiso` (
+    `idusuario_permiso` INT NOT NULL,
+    `MeDi_id` INT NOT NULL,
   `idpermiso` INT NOT NULL,
   PRIMARY KEY (`idusuario_permiso`),
   INDEX `fk_usuariopermiso_mesadirectiva_idx` (`MeDi_id` ASC),
@@ -383,9 +383,29 @@ CREATE TABLE IF NOT EXISTS `dbasochipo`.`usuario_permiso` (
     REFERENCES `dbasochipo`.`permiso` (`idpermiso`)
     ON DELETE NO ACTION
     ON UPDATE NO ACTION)
-ENGINE = InnoDB;
+  ENGINE = InnoDB;
 
 
-SET SQL_MODE=@OLD_SQL_MODE;
-SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
-SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;
+-- -----------------------------------------------------
+-- Table `dbasochipo`.`tbl_alertas`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `dbasochipo`.`tbl_alertas` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `tipo_alerta` VARCHAR(50) NOT NULL,
+  `Mi_id` INT(11) NOT NULL,
+  `fecha` DATE NOT NULL,
+  `leida` TINYINT(1) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`id`),
+  INDEX `fk_alerta_miembro_idx` (`Mi_id` ASC),
+  CONSTRAINT `fk_alerta_miembro`
+    FOREIGN KEY (`Mi_id`)
+    REFERENCES `dbasochipo`.`tbl_miembros` (`Mi_id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE)
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = utf8mb4;
+
+
+  SET SQL_MODE=@OLD_SQL_MODE;
+  SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+  SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;

--- a/modelos/Alertas.php
+++ b/modelos/Alertas.php
@@ -1,0 +1,36 @@
+<?php
+require "../config/Conexion.php";
+
+class Alertas
+{
+    public function __construct()
+    {
+    }
+
+    public function insertar($tipo, $Mi_id, $fecha)
+    {
+        $sql = "INSERT INTO tbl_alertas (tipo_alerta, Mi_id, fecha, leida) VALUES ('$tipo', '$Mi_id', '$fecha', 0)";
+        return ejecutarConsulta($sql);
+    }
+
+    public function marcarLeida($id)
+    {
+        $sql = "UPDATE tbl_alertas SET leida = 1 WHERE id = '$id'";
+        return ejecutarConsulta($sql);
+    }
+
+    public function listar()
+    {
+        $sql = "SELECT * FROM tbl_alertas ORDER BY fecha ASC";
+        return ejecutarConsulta($sql);
+    }
+
+    public function existe($tipo, $Mi_id, $fecha)
+    {
+        $sql = "SELECT id FROM tbl_alertas WHERE tipo_alerta='$tipo' AND Mi_id='$Mi_id' AND fecha='$fecha'";
+        return ejecutarConsulta($sql);
+    }
+}
+
+?>
+

--- a/public/css/alertas.css
+++ b/public/css/alertas.css
@@ -1,0 +1,23 @@
+.alertas-container {
+  margin: 15px 0;
+}
+
+.badge-alerta {
+  display: inline-block;
+  background-color: #ffe0b2;
+  color: #333;
+  padding: 5px 10px;
+  border-radius: 8px;
+  margin: 3px;
+}
+
+.badge-alerta.badge-leida {
+  background-color: #dcedc8;
+}
+
+.badge-alerta a {
+  color: #333;
+  margin-left: 6px;
+  text-decoration: none;
+}
+

--- a/vistas/escritorio.php
+++ b/vistas/escritorio.php
@@ -1,5 +1,8 @@
 <?php
 require 'header.php';
+require '../modelos/Alertas.php';
+$alerta = new Alertas();
+$rspta = $alerta->listar();
 ?>
   <!-- CONTENIDO -->
   <!-- Content Wrapper. Contains page content -->
@@ -14,6 +17,19 @@ require 'header.php';
         <li><a href="#"><i class="fa fa-dashboard"></i> Home</a></li>
         <li class="active">Dashboard</li>
       </ol>
+    </section>
+
+    <section class="content">
+      <div class="alertas-container">
+        <?php while ($reg = $rspta->fetch_object()) { ?>
+          <span class="badge-alerta <?php echo $reg->leida ? 'badge-leida' : ''; ?>">
+            <?php echo $reg->tipo_alerta . ' ' . $reg->fecha; ?>
+            <?php if (!$reg->leida) { ?>
+              <a href="../ajax/alertas.php?op=marcar&id=<?php echo $reg->id; ?>">✔</a>
+            <?php } ?>
+          </span>
+        <?php } ?>
+      </div>
     </section>
     <!-- /.content -->
   </div>

--- a/vistas/header.php
+++ b/vistas/header.php
@@ -42,12 +42,13 @@ if (strlen(session_id()) < 1){
   <link rel="stylesheet" href="../public/plugins/bootstrap-wysihtml5/bootstrap3-wysihtml5.min.css">
 
    <!-- DATATABLES -->
-   <link rel="stylesheet" type="../public/text/css" href="datatables/jquery.dataTables.min.css">    
+   <link rel="stylesheet" type="../public/text/css" href="datatables/jquery.dataTables.min.css">
   <link href="../public/datatables/buttons.dataTables.min.css" rel="stylesheet"/>
   <link href="../public/datatables/responsive.dataTables.min.css" rel="stylesheet"/>
 
   <!-- select mas esteticos -->
   <link  type="text/css"  href="../public/css/bootstrap-select.min.css" rel="stylesheet"/>
+  <link rel="stylesheet" href="../public/css/alertas.css">
 
   
   <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->


### PR DESCRIPTION
## Resumen
- Se añadió la tabla `tbl_alertas` para registrar vencimientos y eventos vinculados a los miembros.
- Se implementó un script `cron/alertas.php` que genera alertas de cuotas pendientes y actividades próximas.
- Se creó la hoja de estilos `public/css/alertas.css` y se enlazó en el header para mostrar badges pastel.
- El dashboard ahora lista las alertas con opción de marcarlas como leídas mediante `ajax/alertas.php`.

## Testing
- `php -l modelos/Alertas.php`
- `php -l cron/alertas.php`
- `php -l ajax/alertas.php`
- `php -l vistas/header.php`
- `php -l vistas/escritorio.php`


------
https://chatgpt.com/codex/tasks/task_e_68af546bcda08321befcbbe557f730c0