### PR TITLE
Add participation record on activity creation

### DIFF
--- a/ajax/actividades.php
+++ b/ajax/actividades.php
@@ -1,0 +1,40 @@
+<?php
+require_once "../modelos/Actividades.php";
+
+$actividades = new Actividades();
+
+$Act_id=isset($_POST["Act_id"])? limpiarCadena($_POST["Act_id"]):"";
+$Act_Nombre=isset($_POST["Act_Nombre"])? limpiarCadena($_POST["Act_Nombre"]):"";
+$Act_descripcion=isset($_POST["Act_descripcion"])? limpiarCadena($_POST["Act_descripcion"]):"";
+$Act_fecha=isset($_POST["Act_fecha"])? limpiarCadena($_POST["Act_fecha"]):"";
+$Mi_Id=isset($_POST["Mi_Id"])? limpiarCadena($_POST["Mi_Id"]):"";
+
+switch($_GET["op"]){
+    case 'guardaryeditar':
+        if(empty($Act_id)){
+            $rspta=$actividades->insertar($Act_Nombre,$Act_descripcion,$Act_fecha,$Mi_Id);
+            echo $rspta?"Actividad registrada":"Actividad no se pudo registrar";
+        }else{
+            // editar no implementado
+        }
+    break;
+
+    case 'listar':
+        $rspta=$actividades->listar();
+        $data=Array();
+        while($reg=$rspta->fetch_object()){
+            $data[]=array(
+                "0"=>$reg->Act_Nombre,
+                "1"=>$reg->Act_descripcion,
+                "2"=>$reg->Act_fecha
+            );
+        }
+        $results=array(
+            "sEcho"=>1,
+            "iTotalRecords"=>count($data),
+            "iTotalDisplayRecords"=>count($data),
+            "aaData"=>$data);
+        echo json_encode($results);
+    break;
+}
+?>

--- a/ajax/participacion.php
+++ b/ajax/participacion.php
@@ -1,0 +1,27 @@
+<?php
+require_once "../modelos/Participacion.php";
+
+$participacion = new Participacion();
+
+switch($_GET["op"]){
+    case 'listar':
+        $rspta=$participacion->listar();
+        $data=Array();
+        while($reg=$rspta->fetch_object()){
+            $data[]=array(
+                "0"=>$reg->Act_Nombre,
+                "1"=>$reg->Mi_Nombres,
+                "2"=>$reg->ParMi_tipo,
+                "3"=>$reg->ParMi_observaciones,
+                "4"=>$reg->ParMi_Registro
+            );
+        }
+        $results=array(
+            "sEcho"=>1,
+            "iTotalRecords"=>count($data),
+            "iTotalDisplayRecords"=>count($data),
+            "aaData"=>$data);
+        echo json_encode($results);
+    break;
+}
+?>

--- a/modelos/Actividades.php
+++ b/modelos/Actividades.php
@@ -1,0 +1,33 @@
+<?php
+require "../config/Conexion.php";
+
+class Actividades
+{
+    public function __construct()
+    {
+    }
+
+    public function insertar($Act_Nombre,$Act_descripcion,$Act_fecha,$Mi_Id)
+    {
+        $sql="INSERT INTO tbl_actividades(Act_Nombre,Act_descripcion,Act_fecha,Act_estado) VALUES ('$Act_Nombre','$Act_descripcion','$Act_fecha','1')";
+        $idactividad=ejecutarConsulta_retornarID($sql);
+        if($idactividad){
+            // validar duplicados
+            $sqlexiste="SELECT ParMi_id FROM tbl_participacionmiembros WHERE Act_id='$idactividad' AND Mi_Id='$Mi_Id'";
+            $existe=ejecutarConsulta($sqlexiste);
+            if($existe->num_rows==0){
+                $sqlpart="INSERT INTO tbl_participacionmiembros(Act_id,Mi_Id,ParMi_tipo,ParMi_observaciones,ParMi_Activo,ParMi_Registro) VALUES ('$idactividad','$Mi_Id','Creador','',1,NOW())";
+                ejecutarConsulta($sqlpart);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    public function listar()
+    {
+        $sql="SELECT * FROM tbl_actividades";
+        return ejecutarConsulta($sql);
+    }
+}
+?>

--- a/modelos/Participacion.php
+++ b/modelos/Participacion.php
@@ -1,0 +1,16 @@
+<?php
+require "../config/Conexion.php";
+
+class Participacion
+{
+    public function __construct()
+    {
+    }
+
+    public function listar()
+    {
+        $sql="SELECT p.ParMi_id,a.Act_Nombre,m.Mi_Nombres, p.ParMi_tipo, p.ParMi_observaciones, p.ParMi_Registro FROM tbl_participacionmiembros p INNER JOIN tbl_actividades a ON p.Act_id=a.Act_id INNER JOIN tbl_miembros m ON p.Mi_Id=m.Mi_id";
+        return ejecutarConsulta($sql);
+    }
+}
+?>

--- a/vistas/participacion.php
+++ b/vistas/participacion.php
@@ -1,0 +1,60 @@
+<?php
+ob_start();
+session_start();
+
+if (!isset($_SESSION["nombre"]))
+{
+  header("Location: login.html");
+}
+else
+{
+if ($_SESSION['compras']==1)
+{
+require 'header.php';
+?>
+<div class="content-wrapper">
+  <section class="content">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="box">
+          <div class="box-header with-border">
+            <h1 class="box-title">Participación inicial</h1>
+          </div>
+          <div class="panel-body table-responsive" id="listadoregistros">
+            <table id="tbllistado" class="table table-striped table-bordered table-condensed table-hover">
+              <thead>
+                <th>Actividad</th>
+                <th>Miembro</th>
+                <th>Tipo</th>
+                <th>Observaciones</th>
+                <th>Registro</th>
+              </thead>
+              <tbody>
+              </tbody>
+              <tfoot>
+                <th>Actividad</th>
+                <th>Miembro</th>
+                <th>Tipo</th>
+                <th>Observaciones</th>
+                <th>Registro</th>
+              </tfoot>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+<?php
+}
+else
+{
+  require 'noacceso.php';
+}
+require 'footer.php';
+?>
+<script type="text/javascript" src="scripts/participacion.js"></script>
+<?php
+}
+ob_end_flush();
+?>

--- a/vistas/scripts/participacion.js
+++ b/vistas/scripts/participacion.js
@@ -1,0 +1,27 @@
+var tabla;
+
+function init(){
+    listar();
+}
+
+function listar(){
+    tabla=$('#tbllistado').dataTable({
+        "aProcessing": true,
+        "aServerSide": true,
+        dom: 'Bfrtip',
+        buttons: ['copyHtml5','excelHtml5','csvHtml5','pdf'],
+        "ajax":{
+            url: '../ajax/participacion.php?op=listar',
+            type : "get",
+            dataType : "json",
+            error: function(e){
+                console.log(e.responseText);
+            }
+        },
+        "bDestroy": true,
+        "iDisplayLength": 5,
+        "order": [[0, "desc"]]
+    }).DataTable();
+}
+
+init();


### PR DESCRIPTION
## Summary
- record creator participation automatically when an activity is added, preventing duplicate records
- add endpoints and view to list initial participation

## Testing
- `php -l ajax/actividades.php modelos/Actividades.php ajax/participacion.php modelos/Participacion.php vistas/participacion.php`


------
https://chatgpt.com/codex/tasks/task_e_68af556a6e708321a0854926ee2c79b7